### PR TITLE
fix broken link in readme

### DIFF
--- a/b2b/README.md
+++ b/b2b/README.md
@@ -279,7 +279,7 @@ Let’s look at how the sign-up flow implementation works in the Teamspace app.
 Our sign-up flow uses the self-service approach offered by Asgardeo. This approach empowers organizations to take control of the onboarding process by enabling organizations to create their own organizations and onboard administrators.
 
   > **Note:**  
-  > Read more on the [Self-Service Approach.](https://wso2.com/asgardeo/docs/guides/organization-management/onboard-org-admins/self-service)
+  > Read more on the [Self-Service Approach.](https://wso2.com/asgardeo/docs/guides/organization-management/onboard-org-admins/self-service-approach)
 
 Visit Teamspace at `https://localhost:3002` and click “Sign Up”.
 


### PR DESCRIPTION
## Purpose
This pull request includes a minor update to the `b2b/README.md` file. The change updates the hyperlink for the "Self-Service Approach" documentation to point to the correct URL.

* Documentation update:
  * [`b2b/README.md`](diffhunk://#diff-94ff724aa0f37324938569ffc7a9eb61766dfe4a61613378289d68b9003a0d23L282-R282): Updated the hyperlink for the "Self-Service Approach" to ensure it directs to the correct page.