### PR TITLE
Fix personalization UI issues

### DIFF
--- a/b2b/web-app/components/sections/sections/settingsSection/personalizationSection/personalizationSectionComponent.tsx
+++ b/b2b/web-app/components/sections/sections/settingsSection/personalizationSection/personalizationSectionComponent.tsx
@@ -156,14 +156,14 @@ export default function PersonalizationSectionComponent(props: PersonalizationSe
         // Use defaultBrandingPreference if brandingPreference is not present
         const updatedBrandingPreference: BrandingPreference = brandingPreference
             ? brandingPreference : defaultBrandingPreference;
-        const activeTheme: string = updatedBrandingPreference.preference.theme.activeTheme;
-
+        const activeTheme: string = (updatedBrandingPreference.preference as { theme: any }).theme.activeTheme;
+    
         // Now updatedBrandingPreference is guaranteed to have the correct structure
-        updatedBrandingPreference.preference.theme[activeTheme].images.logo.imgURL = values.logo_url;
-        updatedBrandingPreference.preference.theme[activeTheme].images.logo.altText = values.logo_alt_text;
-        updatedBrandingPreference.preference.theme[activeTheme].images.favicon.imgURL = values.favicon_url;
-        updatedBrandingPreference.preference.theme[activeTheme].colors.primary.main = values.primary_color || DEFAULT_PRIMARY_COLOR;
-        updatedBrandingPreference.preference.theme[activeTheme].colors.secondary.main = values.secondary_color || DEFAULT_SECONDARY_COLOR;
+        (updatedBrandingPreference.preference as { theme: any }).theme[activeTheme].images.logo.imgURL = values.logo_url;
+        (updatedBrandingPreference.preference as { theme: any }).theme[activeTheme].images.logo.altText = values.logo_alt_text;
+        (updatedBrandingPreference.preference as { theme: any }).theme[activeTheme].images.favicon.imgURL = values.favicon_url;
+        (updatedBrandingPreference.preference as { theme: any }).theme[activeTheme].colors.primary.main = values.primary_color || DEFAULT_PRIMARY_COLOR; // Fallback to default if empty
+        (updatedBrandingPreference.preference as { theme: any }).theme[activeTheme].colors.secondary.main = values.secondary_color || DEFAULT_SECONDARY_COLOR; // Fallback to default if empty
 
         updatedBrandingPreference.name = session.orgId;
         delete (updatedBrandingPreference as any).resolvedFrom;

--- a/b2b/web-app/pages/api/settings/application/listCurrentApplicationInRoot.ts
+++ b/b2b/web-app/pages/api/settings/application/listCurrentApplicationInRoot.ts
@@ -33,7 +33,6 @@ export default async function listCurrentApplicationInRoot(req: NextApiRequest, 
     const decodedAppName = appName.toString().replace(/%20/g, "");
 
     try {
-        console.log("path" + `${getConfig().CommonConfig.AuthorizationConfig.BaseOrganizationUrl}/api/server/v1/applications?filter=name+eq+${decodedAppName}`);
         const fetchData = await fetch(
             `${getConfig().CommonConfig.AuthorizationConfig.BaseOrganizationUrl}/api/server/v1/applications?filter=name+eq+${decodedAppName}`,
                 {


### PR DESCRIPTION
This pull request enhances the `PersonalizationSectionComponent` in the B2B web app by introducing default color handling, improving the UI for color customization, and refining the enterprise plan upgrade flow. It also includes a minor cleanup in the API settings file.

### Personalization Improvements:
* Introduced `DEFAULT_PRIMARY_COLOR` and `DEFAULT_SECONDARY_COLOR` constants for fallback color values when branding preferences are missing. These are applied in multiple places, including the `fetchBrandingPreference` function and form submission logic. (`[[1]](diffhunk://#diff-3e9662d139fd9f7c78503edaff93fa74cb1c8bd865a4dbb13b25040f90744036R52)`, `[[2]](diffhunk://#diff-3e9662d139fd9f7c78503edaff93fa74cb1c8bd865a4dbb13b25040f90744036R135-R139)`, `[[3]](diffhunk://#diff-3e9662d139fd9f7c78503edaff93fa74cb1c8bd865a4dbb13b25040f90744036L153-R167)`, `[[4]](diffhunk://#diff-3e9662d139fd9f7c78503edaff93fa74cb1c8bd865a4dbb13b25040f90744036L172-R178)`)
* Added `PrimaryColorPickerField` and updated `ColorPickerField` to `ButtonColorPickerField` for better handling of primary and secondary color pickers. (`[b2b/web-app/components/sections/sections/settingsSection/personalizationSection/personalizationSectionComponent.tsxR230-R245](diffhunk://#diff-3e9662d139fd9f7c78503edaff93fa74cb1c8bd865a4dbb13b25040f90744036R230-R245)`)

### UI Enhancements:
* Updated the UI to conditionally display color customization fields based on the user's branding scope. If the advanced branding scope is unavailable, a promotional section for upgrading to the enterprise plan is shown with improved styling. (`[[1]](diffhunk://#diff-3e9662d139fd9f7c78503edaff93fa74cb1c8bd865a4dbb13b25040f90744036R317-R397)`, `[[2]](diffhunk://#diff-3e9662d139fd9f7c78503edaff93fa74cb1c8bd865a4dbb13b25040f90744036L384-L447)`)

### Code Cleanup:
* Removed an unnecessary `console.log` statement from the `listCurrentApplicationInRoot` API function. (`[b2b/web-app/pages/api/settings/application/listCurrentApplicationInRoot.tsL36](diffhunk://#diff-cfa6939ccaa71afd1601d65f16965a9ef6ecc0de621df742e6c6ed0c858db73cL36)`)